### PR TITLE
Fix retrieve task from azure devops

### DIFF
--- a/src/providers/AzureDevOpsProvider.ts
+++ b/src/providers/AzureDevOpsProvider.ts
@@ -20,6 +20,25 @@ interface AzWorkItem {
   url?: string;
 }
 
+function parsePossiblyNoisyJson<T>(raw: string): T {
+  const trimmed = raw.trim();
+  try {
+    return JSON.parse(trimmed) as T;
+  } catch {
+    const objectStart = trimmed.indexOf('{');
+    const arrayStart = trimmed.indexOf('[');
+    const firstStart = [objectStart, arrayStart]
+      .filter(i => i >= 0)
+      .sort((a, b) => a - b)[0];
+    if (firstStart === undefined) {
+      throw new Error('No JSON payload found in command output.');
+    }
+
+    const candidate = trimmed.slice(firstStart);
+    return JSON.parse(candidate) as T;
+  }
+}
+
 /**
  * Task provider backed by the **Azure DevOps CLI** (`az boards`).
  *
@@ -228,9 +247,9 @@ export class AzureDevOpsProvider implements ITaskProvider {
   private async fetchWorkItemDetails(queryOutput: string): Promise<void> {
     let ids: number[];
     try {
-      const parsed = JSON.parse(queryOutput);
+      const parsed = parsePossiblyNoisyJson<Record<string, unknown> | Array<Record<string, unknown>>>(queryOutput);
       // az boards query may return { workItems: [{ id }] }, [{ id }], or [{ fields: { 'System.Id': N } }]
-      const items = parsed.workItems ?? parsed;
+      const items = Array.isArray(parsed) ? parsed : ((parsed.workItems as Array<Record<string, unknown>> | undefined) ?? []);
       ids = (items as Array<Record<string, unknown>>).map(w => {
         if (typeof w.id === 'number') { return w.id; }
         // Some formats nest the id in fields
@@ -265,7 +284,7 @@ export class AzureDevOpsProvider implements ITaskProvider {
           log.debug('AzureDevOpsProvider: exec → az %s', wiArgs.join(' '));
           return execShell('az', wiArgs, { timeout: 15_000 }).then(({ stdout }) => {
             log.debug('AzureDevOpsProvider: work-item %d stdout (%d chars) → %s', id, stdout.length, stdout.slice(0, 1000));
-            return JSON.parse(stdout) as AzWorkItem;
+            return parsePossiblyNoisyJson<AzWorkItem>(stdout);
           });
         }),
       );

--- a/src/providers/execShell.ts
+++ b/src/providers/execShell.ts
@@ -12,7 +12,7 @@ function shellEscape(arg: string): string {
 
 /**
  * Build the full command string (single level of escaping)
- * to be passed as the argument of `<shell> -ilc '<cmd> <args…>'`.
+ * to be passed as the argument of `<shell> -lc '<cmd> <args…>'`.
  */
 function buildShellCmd(cmd: string, args: readonly string[]): string {
   return [cmd, ...args].map(shellEscape).join(' ');
@@ -20,9 +20,9 @@ function buildShellCmd(cmd: string, args: readonly string[]): string {
 
 /**
  * Thin wrapper around `execFile` that always runs through the user's **login**
- * shell (`-ilc`) so that Homebrew / custom PATH entries are resolved correctly.
+ * shell (`-lc`) so that Homebrew / custom PATH entries are resolved correctly.
  *
- * Uses `execFile(shell, ['-ilc', cmd])` — no intermediate `/bin/sh`, so
+ * Uses `execFile(shell, ['-lc', cmd])` — no intermediate `/bin/sh`, so
  * shell arguments are only escaped once.
  */
 export function execShell(
@@ -31,7 +31,7 @@ export function execShell(
   opts: ExecFileOptions,
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    execFile(userShell, ['-ilc', buildShellCmd(cmd, args)], opts, (err, stdout, stderr) => {
+    execFile(userShell, ['-lc', buildShellCmd(cmd, args)], opts, (err, stdout, stderr) => {
       if (err) { reject(err); } else { resolve({ stdout: String(stdout), stderr: String(stderr) }); }
     });
   });
@@ -46,6 +46,6 @@ export function execShellOk(
   opts: ExecFileOptions = {},
 ): Promise<boolean> {
   return new Promise((resolve) => {
-    execFile(userShell, ['-ilc', buildShellCmd(cmd, args)], opts, (err) => resolve(!err));
+    execFile(userShell, ['-lc', buildShellCmd(cmd, args)], opts, (err) => resolve(!err));
   });
 }


### PR DESCRIPTION
- Passaggio da shell interattiva a shell login non interattiva in [execShell.ts:34](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) e [execShell.ts:49](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Parsing JSON reso robusto nel provider Azure DevOps con fallback che cerca l’inizio payload JSON in [AzureDevOpsProvider.ts:23](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Uso del parser robusto sia nella risposta di query che nel dettaglio work item in [AzureDevOpsProvider.ts:250](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) e [AzureDevOpsProvider.ts:287](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).